### PR TITLE
Changing overlay.cpp

### DIFF
--- a/src/vulkan/overlay.cpp
+++ b/src/vulkan/overlay.cpp
@@ -24,6 +24,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <assert.h>
 
 #include <mutex>


### PR DESCRIPTION
The project currently does not compile only cloning from source, with errors such as "‘fprintf’ was not declared in this scope" and "‘stderr’ was not declared in this scope". This change is necessary for it to compile successfully